### PR TITLE
fix gem name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A plugin for diabetes-related plugins for lita
 
 ## Installation
 
-Add lita-diabetes-handler to your Lita instance's Gemfile:
+Add lita-diabetes to your Lita instance's Gemfile:
 
 ``` ruby
-gem "lita-diabetes-handler"
+gem "lita-diabetes"
 ```
 
 ## Configuration


### PR DESCRIPTION
The example Gemfile line does not match the gem name in the gemspec
file, which makes bundler sad.
