### PR TITLE
add git gem source to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A plugin for diabetes-related plugins for lita
 
 ## Installation
 
-Add lita-diabetes-handler to your Lita instance's Gemfile:
+Add lita-diabetes to your Lita instance's Gemfile:
 
 ``` ruby
-gem "lita-diabetes-handler"
+gem "lita-diabetes"
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A plugin for diabetes-related plugins for lita
 Add lita-diabetes to your Lita instance's Gemfile:
 
 ``` ruby
-gem "lita-diabetes"
+gem "lita-diabetes", :git => "https://github.com/dosman711/lita-diabetes.git"
 ```
 
 ## Configuration


### PR DESCRIPTION
If you're not planning to release this to rubygems.org (and I wouldn't bother if I were you), this would be convenient to have in the example.
